### PR TITLE
Update email authentication

### DIFF
--- a/app_django/settings.py
+++ b/app_django/settings.py
@@ -195,3 +195,18 @@ STATIC_URL = "static/"
 # Default primary key field type
 # ------------------------
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+
+
+
+# ------------------------
+# Email settings
+# ------------------------
+EMAIL_BACKEND = os.getenv("EMAIL_BACKEND")
+EMAIL_HOST = os.getenv("EMAIL_HOST")
+EMAIL_PORT = int(os.getenv("EMAIL_PORT", 587))
+EMAIL_USE_TLS = bool(os.getenv("EMAIL_USE_TLS", True))
+EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER")
+EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD")
+DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL")
+ADMIN_EMAIL = os.getenv("ADMIN_EMAIL")

--- a/provision/management/commands/testmail.py
+++ b/provision/management/commands/testmail.py
@@ -1,0 +1,14 @@
+
+from django.core.management.base import BaseCommand
+from django.contrib.auth.models import User
+from provision.utils.mail_manager import MailFormation, MailManager
+
+
+class Command(BaseCommand):
+    help = "Test sending email"
+
+    def handle(self, *args, **kwargs):
+        user = User(username="toan", email="toanvippk115@gmail.com")
+        subject, message, from_email, recipient_list = MailFormation.code_registration(user, "654321")
+        MailManager.send_mail(subject, message, from_email, recipient_list)
+        self.stdout.write(self.style.SUCCESS("✅ Test email sent successfully!"))

--- a/provision/utils/mail_manager.py
+++ b/provision/utils/mail_manager.py
@@ -1,0 +1,39 @@
+from django.core.mail import send_mail
+from django.conf import settings
+
+
+class MailFormation:
+    @staticmethod
+    def code_registration(user, code):
+        return (
+            "Verify your email",
+            f"Hello {user.username},\n\nYour verification code is: {code}\n\nThank you!",
+            settings.DEFAULT_FROM_EMAIL,
+            [user.email],
+        )
+
+    @staticmethod
+    def code_reset_password(user, code):
+        return (
+            "Reset your password",
+            f"Hello {user.username},\n\nYour password reset code is: {code}\n\nThank you!",
+            settings.DEFAULT_FROM_EMAIL,
+            [user.email],
+        )
+
+    @staticmethod
+    def notify_admin(subject, message):
+        return subject, message, settings.DEFAULT_FROM_EMAIL, [settings.ADMIN_EMAIL]
+
+    @staticmethod
+    def notify_user(subject, message, user):
+        return subject, message, settings.DEFAULT_FROM_EMAIL, [user.email]
+
+
+class MailManager:
+    @staticmethod
+    def send_mail(subject, message, from_email, recipient_list, fail_silently=False):
+        send_mail(subject, message, from_email, recipient_list, fail_silently=fail_silently)
+
+
+

--- a/provision/utils/token_manager.py
+++ b/provision/utils/token_manager.py
@@ -1,0 +1,28 @@
+import random
+import time
+
+class OTPManager:
+    # Lưu OTP trong RAM: {user_id: (otp_code, expire_time)}
+    otp_store = {}
+
+    @staticmethod
+    def generate_otp(user_id, length=6, expire_seconds=300):
+        """Tạo OTP cho từng user riêng biệt"""
+        otp = random.randint(10**(length-1), 10**length - 1)
+        expire_time = time.time() + expire_seconds
+        OTPManager.otp_store[user_id] = (otp, expire_time)
+        return otp
+
+    @staticmethod
+    def verify_otp(user_id, otp):
+        """Xác thực OTP theo user"""
+        if user_id not in OTPManager.otp_store:
+            return False
+        stored_otp, expire_time = OTPManager.otp_store[user_id]
+        if time.time() > expire_time:
+            del OTPManager.otp_store[user_id]  # OTP hết hạn
+            return False
+        if stored_otp == otp:
+            del OTPManager.otp_store[user_id]  # Xác thực xong xóa luôn
+            return True
+        return False

--- a/provision/views/camera_views.py
+++ b/provision/views/camera_views.py
@@ -166,6 +166,11 @@ class CameraWebSocketView(AsyncWebsocketConsumer):
 
     async def disconnect(self, close_code):
         # TODO: Cleanup if needed
+        """
+        Called when the socket is closed. This is the last message we will
+        receive from the client, and we should clean up any resources we've
+        allocated at this point.
+        """
         pass
 
     async def receive(self, text_data):


### PR DESCRIPTION
feat: implement email-based OTP verification

- Added OTPManager to generate and verify OTPs in RAM per user
- Integrated OTP generation and verification in views for email authentication
- OTPs are now associated with user_id and expire automatically after 5 minutes
- Removed need to store OTPs in database
- Ensures multiple users can request OTPs concurrently without conflicts

## Summary by Sourcery

Implement email-based OTP authentication by adding in-memory OTP management, email utilities, and integrating OTP generation and verification into password reset workflows, along with email configuration and a test mail command.

New Features:
- Add OTPManager to generate and verify per-user OTPs in memory with 5-minute expiration
- Introduce MailFormation and MailManager utilities for composing and sending verification and reset emails
- Integrate OTP generation in ResetPasswordRequestView to send password reset codes via email
- Integrate OTP verification in ResetPasswordConfirmView to validate codes and update passwords
- Create a management command testmail to validate email sending functionality

Enhancements:
- Remove database storage of OTPs in favor of an in-memory store for concurrent requests
- Update Swagger schemas in user views with request bodies and response definitions
- Add email backend and host configuration settings to Django settings
- Add documentation comment to camera_views disconnect method